### PR TITLE
Fix a missing dash in mime type vnd.adobe.air-application-installer-package

### DIFF
--- a/lib/mime/types/application
+++ b/lib/mime/types/application
@@ -248,7 +248,7 @@ application/vnd.accpac.simply.aso 'IANA,[Leow]
 application/vnd.accpac.simply.imp 'IANA,[Leow]
 application/vnd.acucobol 'IANA,[Lubin]
 application/vnd.acucorp @atc,acutc :7bit 'IANA,[Lubin]
-application/vnd.adobe.air-applicationinstaller-package+zip @air :base64
+application/vnd.adobe.air-application-installer-package+zip @air :base64
 application/vnd.adobe.fxp 'IANA,[Brambley],[Heintz]
 application/vnd.adobe.partial-upload 'IANA,[Otala]
 application/vnd.adobe.xdp+xml 'IANA,[Brinkman]


### PR DESCRIPTION
There was a typo in issue #6 and then commit f53f6b7e186e5d6266c4aeca47ef509a6bc84d2c that made it into v1.18.
Just add a dash in "vnd.adobe.air-applicationinstaller-package" before "installer".

Source :
http://www.adobe.com/devnet/air/articles/air_badge_install.html
  and everywhere else on the internetz.
