### PR TITLE
Add image/x-xcf and image/x-compressed-xcf

### DIFF
--- a/lib/mime/types/image.nonstandard
+++ b/lib/mime/types/image.nonstandard
@@ -1,6 +1,7 @@
 *image/pjpeg :base64 =Fixes a bug with IE6 and progressive JPEGs
 image/x-bmp @bmp
 image/x-cmu-raster @ras
+image/x-compressed-xcf @xcfbz2,xcfgz =see-also:image/x-xcf
 image/x-paintshoppro @psp,pspimage :base64
 image/x-pict
 image/x-portable-anymap @pnm :base64
@@ -13,5 +14,6 @@ image/x-vnd.dgn @dgn
 image/x-win-bmp
 image/x-xbitmap @xbm :7bit
 image/x-xbm @xbm :7bit
+image/x-xcf @xcf '{XCF=http://git.gnome.org/browse/gimp/tree/devel-docs/xcf.txt}
 image/x-xpixmap @xpm :8bit
 image/x-xwindowdump @xwd :base64


### PR DESCRIPTION
Please check if correct.

Is it possible to add xcf.gz and xcf.bz2 (with the period) as image/x-compressed-xcf, too? I didn't try because I tar.gz and tar.bz2 isn't in the list, too.
