### PR TITLE
Add mime-type for RSS

### DIFF
--- a/lib/mime/types/application.nonstandard
+++ b/lib/mime/types/application.nonstandard
@@ -37,6 +37,7 @@
 *application/vnd.sun.xml.writer.template @stw
 *application/word @doc,dot 'LTSW
 application/epub+zip @epub
+application/rss+xml @rss
 application/x-bcpio @bcpio 'LTSW
 application/x-bleeper @bleep :base64
 application/x-bzip2 @bz2


### PR DESCRIPTION
As there is no official RFC but only a draft at http://www.rssboard.org/rss-mime-type-application.txt I added the mime-type to the file `application.nonstandard`.
