### PR TITLE
Make MIME::Types Enumerable

### DIFF
--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -596,6 +596,14 @@ module MIME
     def defined_types #:nodoc:
       @type_variants.values.flatten
     end
+  
+    def count
+      @type_variants.size
+    end
+  
+    def each
+      @type_variants.each { |t| yield t }
+    end
 
     @__types__ = self.new(VERSION)
 
@@ -818,6 +826,16 @@ module MIME
       #   end
       def [](type_id, flags = {})
         @__types__[type_id, flags]
+      end
+
+      include Enumerable
+  
+      def count
+        @__types__.count
+      end
+
+      def each
+        @__types__.each {|t| yield t }
       end
 
       # Return the list of MIME::Types which belongs to the file based on

--- a/test/test_mime_types.rb
+++ b/test/test_mime_types.rb
@@ -70,6 +70,14 @@ class TestMIME_Types < MiniTest::Unit::TestCase #:nodoc:
     assert_equal(MIME::Types.of('gif', true), MIME::Types['image/gif'])
     assert(MIME::Types.of('zzz').empty?)
   end
+  
+  def test_class_enumerable
+    assert( MIME::Types.any? {|types| types[0] == 'text/plain'} )
+  end
+  
+  def test_class_count
+    assert(MIME::Types.count > 42, "A lot of types are expected to be known.")
+  end
 
   def test_ebook_formats
     assert_equal( MIME::Types['application/x-mobipocket-ebook'],  MIME::Types.type_for("book.mobi"))


### PR DESCRIPTION
I needed that to populate a web server configuration database and thought it would benefit others.

(I did read the contribution guidelines albeit after committing so I realized too late that you request a topic branch and my git-fu is too basic to do it now.)
