### PR TITLE
Add .js extension to text/javascript

### DIFF
--- a/lib/mime/types/text.obsolete
+++ b/lib/mime/types/text.obsolete
@@ -1,6 +1,6 @@
 !text/directory 'IANA,RFC2425,RFC6350
 !text/ecmascript 'IANA,RFC4329
-!text/javascript 'IANA,RFC4329
+!text/javascript @js 'IANA,RFC4329
 !text/x-rtf @rtf :8bit =use-instead:text/rtf
 !text/x-vnd.flatland.3dml =use-instead:model/vnd.flatland.3dml
 *!text/comma-separated-values @csv :8bit =use-instead:text/csv


### PR DESCRIPTION
According to [RFC 4329, section 7.1](http://tools.ietf.org/html/rfc4329#section-7.1), `text/javascript` has the ext .js
