### PR TITLE
Improve main documentation example

### DIFF
--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -25,6 +25,12 @@ module MIME
   #  puts text == 'text/plain'       # => true
   #  puts MIME::Type.simplified('x-appl/x-zip') # => 'appl/zip'
   #
+  #  puts MIME::Types.any? { |type|
+  #    type.content_type == 'text/plain'
+  #  }                               # => true
+  #  puts MIME::Types.all?(&:registered?)
+  #                                  # => false
+  #
   class Type
     # The released version of Ruby MIME::Types
     VERSION = '1.23'


### PR DESCRIPTION
- Fix the main example for `MIME::Types` to match the one in the README.
- Copied the last two examples from the README into the main documentation example.
