### PR TITLE
Travis - Add Ruby 2.1.0, fix Rubinius build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ language: ruby
 notifications:
   email: true
 rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3
   - 1.9.2
   - jruby-19mode
-  - rbx-19mode
+  - rbx
 # - ruby-head
 # - jruby-head
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,7 @@ gem "hoe-travis", "~>1.2", :group => [:development, :test]
 gem "rake", "~>10.0", :group => [:development, :test]
 gem "simplecov", "~>0.7", :group => [:development, :test]
 gem "hoe", "~>3.7", :group => [:development, :test]
-
+gem "rubysl", "~>2.0", :platforms => :rbx, :group => [:development, :test]
+gem "rubinius-developer_tools", :platforms => :rbx, :group => [:development, :test]
+gem "psych", :platforms => :rbx, :group => [:development, :test]
 # vim: syntax=ruby


### PR DESCRIPTION
1. Added 2.1.0 to Travis.
2. Updated rbx-19mode to rbx.
3. Added Rubinius gems to Gemfile

I edited the Gemfile directly, rather than modifying the Rakefile as instructed by the comment because it wasn't clear to me how to use more complex gem directives (namely those using 'platforms') through hoe.  I also noted that the Rakefile and Gemfile are out of sync (e.g. minitest) so it's not clear to me that the Gemfile comment still applies.

I'm happy to update the Rakefile if I can get some guidance as to how to incorporate the platforms option in the gem directive.
