### PR TITLE
adds ttf and otf extensions to application/font-sfnt

### DIFF
--- a/type-lists/application.yaml
+++ b/type-lists/application.yaml
@@ -1128,6 +1128,9 @@
 - !ruby/object:MIME::Type
   content-type: application/font-sfnt
   encoding: base64
+  extensions:
+  - otf
+  - ttf
   references:
   - IANA
   - ! '[Levantovsky]'


### PR DESCRIPTION
as per: http://www.iana.org/assignments/media-types/application/font-sfnt

It seems that the official recommendation from IANA, and one that is preferred by Chrome (and other browsers in the future) is that ttf and otf fonts are to be served with the `application/font-sfnt` media type. 

This pull request only adds the extensions to the existing `application/font-sfnt` definition in the `type-lists/application.yml` file. It does not remove these extensions from the other media types they were previously registered with, as I was unsure of how you normally handle this case (extensions being mapped to a new media type). 

Also, do we need to do something to indicate priority so that `application/font-sfnt` appears before the other media types when using `MIME::Types.type_for`? 

Thanks for considering this patch, and thank you for creating/maintaining the `mime-types` gem.
