### PR TITLE
Added mime type for MS Outlook application

### DIFF
--- a/type-lists/application.yaml
+++ b/type-lists/application.yaml
@@ -9505,6 +9505,12 @@
     - application/vnd.ms-officetheme
   registered: true
 - !ruby/object:MIME::Type
+  content-type: application/vnd.ms-outlook
+  encoding: base64
+  extensions:
+  - msg
+  registered: false
+- !ruby/object:MIME::Type
   content-type: application/vnd.ms-pki.seccat
   encoding: base64
   extensions:


### PR DESCRIPTION
Added content type ‘application/vnd.ms-outlook’ for the application MS
Outlook with the file extension ‘.msg’. This is not registered in IANA
but found the content type at
http://www.digitalpreservation.gov/formats/fdd/fdd000379.shtml.
