### PR TITLE
remove unnecessary object duplication

### DIFF
--- a/lib/mime/types/loader.rb
+++ b/lib/mime/types/loader.rb
@@ -56,9 +56,7 @@ class MIME::Types::Loader
   # This method is aliased to #load.
   def load_json
     Dir[json_path].sort.each do |f|
-      types = self.class.load_from_json(f).map { |type|
-        MIME::Type.new(type)
-      }
+      types = self.class.load_from_json(f)
       container.add(*types, :silent)
     end
     container


### PR DESCRIPTION
`load_from_json` returns a list of newly created MIME::Type objects, so
there is no need to loop through all of them again, convert them to
hashes, then allocate duplicate MIME::Type objects.

<3<3
