### PR TITLE
Use `JSON.parse` to limit exposure

### DIFF
--- a/lib/mime/types/loader.rb
+++ b/lib/mime/types/loader.rb
@@ -199,7 +199,7 @@ class MIME::Types::Loader
     # shipped with the mime-types library.
     def load_from_json(filename)
       require 'json'
-      JSON.load(read_file(filename)).map { |type| MIME::Type.new(type) }
+      JSON.parse(read_file(filename)).map { |type| MIME::Type.new(type) }
     end
 
     private


### PR DESCRIPTION
As far as I can tell, there are no pressing reasons for this change (as in, this is
not addressing an immediate security threat). It's just a preventive measure to
reduce unnecessary exposure.

---

Using `JSON.load` on untrusted input is considered unsafe. While the MIME type
definition files would presumably come from a trusted source, there doesn't seem
to be a need for the "extra" stuff that `JSON.load` does in here, so switching
over to the safer `JSON.parse` API should help to reduce exposure.
