### PR TITLE
Adding mime_type method

### DIFF
--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -121,6 +121,11 @@ class MIME::Type
     yield self if block_given?
   end
 
+  #Returns the mime type
+  def mime_type
+    return "#{self.media_type}/#{self.sub_type}"
+  end
+
   # Returns +true+ if the simplified type matches the current
   def like?(other)
     if other.respond_to?(:simplified)


### PR DESCRIPTION
Adds a simple way to get the mime type of an object. I feel this particular feature is an important one, but is missing.
