### PR TITLE
Set Container default_proc when marshal loaded

### DIFF
--- a/lib/mime/types/cache.rb
+++ b/lib/mime/types/cache.rb
@@ -67,6 +67,7 @@ class MIME::Types
     end
 
     def marshal_load(hash)
+      self.default_proc = ->(h, k) { h[k] = [] }
       self.merge!(hash)
     end
   end

--- a/test/test_mime_types_cache.rb
+++ b/test/test_mime_types_cache.rb
@@ -75,4 +75,16 @@ class TestMIMETypesCache < Minitest::Test
       MIME::Types['text/html']
     end
   end
+
+  def test_container_marshalling
+    container = MIME::Types::Container.new
+    # default proc should return []
+    assert_equal([], container['abc'])
+
+    marshalled = Marshal.dump(container)
+    loaded_container = Marshal.load(marshalled)
+
+    # default proc should still return []
+    assert_equal([], loaded_container['abcd'])
+  end
 end


### PR DESCRIPTION
Marshal.load does not initialize the object so the default_proc doesn't get set when loaded from the cache
