### PR TITLE
Add woff2 to application/font-woff extensions

### DIFF
--- a/type-lists/application.yaml
+++ b/type-lists/application.yaml
@@ -1376,6 +1376,7 @@
   encoding: base64
   extensions:
   - woff
+  - woff2
   references:
   - IANA
   - "[W3C]"


### PR DESCRIPTION
Adds `woff2` to `application/font-woff`

Ran into this when attempting to upload woff2 fonts to S3 using the aws-sdk. 

Let me know if I should revert the white space changes seen in the diff. 

Thank you!