### PR TITLE
Avoid circular require when you do require 'mime/types/columnar'

### DIFF
--- a/lib/mime/types/loader.rb
+++ b/lib/mime/types/loader.rb
@@ -69,7 +69,7 @@ class MIME::Types::Loader
   # Loads a MIME::Types registry from columnar files recursively found in
   # +path+.
   def load_columnar
-    require 'mime/types/columnar'
+    require 'mime/types/columnar' unless defined?(MIME::Types::Columnar)
     container.extend(MIME::Types::Columnar)
     container.load_base_data(path)
 


### PR DESCRIPTION
Fixes warnings/backtrace when you are using ruby -w.