### PR TITLE
Record all extensions when using the columnar store

### DIFF
--- a/lib/mime/types/columnar.rb
+++ b/lib/mime/types/columnar.rb
@@ -26,7 +26,7 @@ module MIME::Types::Columnar
     @__root__ = path
 
     each_file_line('content_type', false) do |line|
-      content_type, extensions = line.split
+      content_type, *extensions = line.split
 
       type = MIME::Type::Columnar.new(self, content_type, extensions)
       @__mime_data__ << type


### PR DESCRIPTION
Without this, only the first extension will be recorded.  This breaks common things like `MIME::Types.type_for('filename.jpg')`.  I think we should release 2.6.1 right away with this and the no circular require patch.