### PR TITLE
Fix a section link in README.rdoc [ci skip]

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,7 +30,7 @@ is a new default registry storage format that greatly reduces the initial
 memory use of the mime-types library. This feature is enabled by requiring
 +mime/types/columnar+ instead of +mime/types+ with a small performance cost and
 no change in *total* memory use if certain methods are called (see {Columnar
-Store}[https://github.com/mime-types/ruby-mime-types#columnar-store] for more details).
+Store}[#label-Columnar+Store] for more details).
 The second new feature is a logger interface that conforms to the expectations of
 an ActiveSupport::Logger so that warnings can be written to an application's log
 rather than the default location for +warn+. This interface may be used for other

--- a/README.rdoc
+++ b/README.rdoc
@@ -30,11 +30,11 @@ is a new default registry storage format that greatly reduces the initial
 memory use of the mime-types library. This feature is enabled by requiring
 +mime/types/columnar+ instead of +mime/types+ with a small performance cost and
 no change in *total* memory use if certain methods are called (see {Columnar
-Store}[#columnar-store] for more details). The second new feature is a logger
-interface that conforms to the expectations of an ActiveSupport::Logger so that
-warnings can be written to an application's log rather than the default
-location for +warn+. This interface may be used for other logging purposes in
-the future.
+Store}[https://github.com/mime-types/ruby-mime-types#columnar-store] for more details).
+The second new feature is a logger interface that conforms to the expectations of
+an ActiveSupport::Logger so that warnings can be written to an application's log
+rather than the default location for +warn+. This interface may be used for other
+logging purposes in the future.
 
 mime-types 2.6 is the last planned version of mime-types 2.x, so deprecation
 warnings are no longer cached but provided every time the method is called.


### PR DESCRIPTION
This pull request fix the link to columnar store section.

Before

![screenshot 2015-05-27 09 39 35](https://cloud.githubusercontent.com/assets/1000669/7826998/4de1d480-0454-11e5-99bb-cbb2b7a2b47b.png)

After

![screenshot 2015-05-27 09 39 57](https://cloud.githubusercontent.com/assets/1000669/7827002/5c556b76-0454-11e5-8061-76f2f13984c0.png)

View [Rendered README.rdoc](https://github.com/mime-types/ruby-mime-types/blob/a58ebd1a6b466deb9e2a86bb52cb88b46dfd44d5/README.rdoc)