### PR TITLE
Add Ruby 2.3, 2.4 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: ruby
 rvm:
+  - 2.4.1
+  - 2.3.4
   - 2.2.3
   - 2.1.6
   - 2.0.0
@@ -16,6 +18,7 @@ matrix:
     - rvm: jruby-9.0.0.0.pre2
     - rvm: ruby-head
     - rvm: ruby-head-clang
+  fast_finish: true
 gemfile:
   - Gemfile
 before_script:


### PR DESCRIPTION
Hello,

I want to add Ruby 2.3 and 2.4 to Travis CI.

Adding `fast_finish` is to get the Travis result as faster without waiting the result of the `allow_failures` items.
  See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/ for detail.

Thanks.