### PR TITLE
Add __instances__ entry when loading from cache

### DIFF
--- a/lib/mime/types/registry.rb
+++ b/lib/mime/types/registry.rb
@@ -55,8 +55,9 @@ class << MIME::Types
   end
 
   def load_default_mime_types(mode = load_mode)
-    @__types__ = MIME::Types::Cache.load
-    unless @__types__
+    if @__types__ = MIME::Types::Cache.load
+      __instances__.add(@__types__)
+    else
       @__types__ = MIME::Types::Loader.load(mode)
       MIME::Types::Cache.save(@__types__)
     end

--- a/test/test_mime_types_cache.rb
+++ b/test/test_mime_types_cache.rb
@@ -42,6 +42,15 @@ describe MIME::Types::Cache do
       assert_equal(nil, MIME::Types::Cache.load)
     end
 
+    it 'registers the data to be updated by #add_extensions' do
+      MIME::Types::Cache.save
+      reset_mime_types
+      assert_equal([], MIME::Types.type_for('foo.additional'))
+      html = MIME::Types['text/html'][0]
+      html.add_extensions('additional')
+      assert_equal([html], MIME::Types.type_for('foo.additional'))
+    end
+
     it 'outputs an error when there is an invalid version' do
       v = MIME::Types::Data::VERSION
       MIME::Types::Data.send(:remove_const, :VERSION)


### PR DESCRIPTION
Currently, things like `add_extension` don't work after loading from cache.