### PR TITLE
Calculate priority from MIME types of same family

### DIFF
--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -151,7 +151,7 @@ class MIME::Type
   # before unregistered or obsolete content types.
   def priority_compare(other)
     pc = simplified <=> other.simplified
-    if pc.zero?
+    if pc.zero? || !(extensions & other.extensions).empty?
       pc = if (reg = registered?) != other.registered?
              reg ? -1 : 1 # registered < unregistered
            elsif (comp = complete?) != other.complete?

--- a/test/test_mime_type.rb
+++ b/test/test_mime_type.rb
@@ -330,21 +330,32 @@ describe MIME::Type do
       assert_priority text_1, text_1p, text_2
     end
 
-    it 'sorts (2) based on the registration state' do
+    it 'sorts (2) based on extensions' do
+      text_1.extensions = ["foo", "bar"]
+      text_2.extensions = ["foo"]
+
+      assert_priority_same text_1, text_2
+
+      text_2.registered = true
+
+      assert_priority_more text_1, text_2
+    end
+
+    it 'sorts (3) based on the registration state' do
       text_1.registered = text_1p.registered = true
       text_1b = mime_type(text_1) { |t| t.registered = false }
 
       assert_priority text_1, text_1p, text_1b
     end
 
-    it 'sorts (3) based on the completeness' do
+    it 'sorts (4) based on the completeness' do
       text_1.extensions = text_1p.extensions = '1'
       text_1b = mime_type(text_1) { |t| t.extensions = nil }
 
       assert_priority text_1, text_1p, text_1b
     end
 
-    it 'sorts (4) based on obsolete status' do
+    it 'sorts (5) based on obsolete status' do
       text_1.obsolete = text_1p.obsolete = false
       text_1b = mime_type(text_1) { |t| t.obsolete = true }
 


### PR DESCRIPTION
Some MIME types are in the same family, but their #simplified values aren't the same. One such example are "text/comma-separated-values" and "text/csv" MIME types. The former is obsolete and unregistered, while the latter is not obsolete and registered, but mime-types would still rank "text/comma-separated-values" higher because it just looks at the alphabetic order.

We check whether MIME types are belong to the same family by checking whether they have common extensions.

Fixes https://github.com/mime-types/ruby-mime-types/issues/131.