### PR TITLE
Update Travis CI Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 ---
 language: ruby
 rvm:
-  - 2.6.0-preview1
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - 2.2.10
   - 2.1.10
-  - jruby-9.1.9.0
+  - jruby-9.2.5.0
+  - jruby-9.1.17.0
   - jruby-9.0.5.0
   - jruby-head
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: 2.6.0-preview1
     - rvm: jruby-head
     - rvm: ruby-head
   fast_finish: true


### PR DESCRIPTION
Bump the Ruby versions specified in the Travis CI config to their latest versions. This includes [Ruby 2.6.0](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/), which was released last month on the 25th. (2018/12/25)