### PR TITLE
Intern content type strings

### DIFF
--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -537,11 +537,28 @@ class MIME::Type
     match = MEDIA_TYPE_RE.match(type_string)
     fail InvalidContentType, type_string if match.nil?
 
-    @content_type                  = type_string
+    @content_type                  = intern_string(type_string)
     @raw_media_type, @raw_sub_type = match.captures
-    @simplified                    = MIME::Type.simplified(match)
-    @i18n_key                      = MIME::Type.i18n_key(match)
+    @simplified                    = intern_string(MIME::Type.simplified(match))
+    @i18n_key                      = intern_string(MIME::Type.i18n_key(match))
     @media_type, @sub_type         = MEDIA_TYPE_RE.match(@simplified).captures
+
+    @raw_media_type = intern_string(@raw_media_type)
+    @raw_sub_type = intern_string(@raw_sub_type)
+    @media_type = intern_string(@media_type)
+    @sub_type = intern_string(@sub_type)
+  end
+
+  if String.method_defined?(:-@)
+    def intern_string(string)
+      -string
+    end
+  else
+    # MRI 2.2 and older don't have a method for string interning,
+    # so we simply freeze them for keeping a similar interface
+    def intern_string(string)
+      string.freeze
+    end
   end
 
   def xref_map(values, helper)


### PR DESCRIPTION
While running a memory profiler against our app, I noticed mime-types was holding onto a lot of duplicated strings:

```
3163  "application"
1577  /tmp/bundle/ruby/2.5.0/gems/mime-types-3.2.2/lib/mime/type.rb:543
1577  /tmp/bundle/ruby/2.5.0/gems/mime-types-3.2.2/lib/mime/type.rb:546
```

The idea here is to apply [`String#@-`](https://ruby-doc.org/core-2.5.5/String.html#method-i-2D-40) to as much as possible deduplicate these strings.

Note that regardless of wether they are duplicates or not, they will be frozen (which IMO is a good thing).