### PR TITLE
IANA Provisional Registration Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# NOTE: This file is present to keep Travis CI happy. Edits to it will not
-# be accepted.
+# NOTE: This file is not the canonical source of dependencies. Edit the
+# Rakefile, instead.
 
 source "https://rubygems.org/"
 

--- a/History.md
+++ b/History.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## NEXT / 2021-MM-DD
+## 3.4.0 / 2021-11-15
+
+- 1 minor enhancement:
+
+  - Added a new field to `MIME::Type` for checking provisional registrations
+    from IANA. [#157]
 
 - Documentation:
 
-  - Kevin Menard synced the documentation so that all examples are correct
-    [#153].
+  - Kevin Menard synced the documentation so that all examples are correct.
+    [#153]
 
 - Administrivia:
 
@@ -13,8 +18,8 @@
     CI exclusion list; it refuses to run successfully.
   - Removed the Travis CI configuration and changed it to Github Workflows
     [#150]. Removed Coveralls configuration.
-  - Igor Victor added TruffleRuby to the Travis CI configuration [#149].
-  - Koichi ITO loosened an excessively tight dependency [#147].
+  - Igor Victor added TruffleRuby to the Travis CI configuration. [#149]
+  - Koichi ITO loosened an excessively tight dependency. [#147]
   - Started using `standardrb` for Ruby formatting and validation.
 
 ## 3.3.1 / 2019-12-26
@@ -76,7 +81,7 @@
     because when Enumerable#inject isn't provided a starting value, the first
     value is used as the default value. In every case where this error was
     happening, the result was supposed to be an array containing Set objects
-    so they can be reduced to a single Set. [#117], [#127], [#134].
+    so they can be reduced to a single Set. [#117], [#127], [#134]
 
   - Fixed an uncontrolled growth bug in MIME::Types::Container where a key
     miss would create a new entry with an empty Set in the container. This

--- a/History.md
+++ b/History.md
@@ -21,6 +21,7 @@
   - Igor Victor added TruffleRuby to the Travis CI configuration. [#149]
   - Koichi ITO loosened an excessively tight dependency. [#147]
   - Started using `standardrb` for Ruby formatting and validation.
+  - Moved `deps:top` functionality to a support file.
 
 ## 3.3.1 / 2019-12-26
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -65,6 +65,7 @@ files). A MIME::Type stores the known information about one MIME type.
    puts text.ascii?                # => true
    puts text.obsolete?             # => false
    puts text.registered?           # => true
+   puts text.provisional?          # => false
    puts text.complete?             # => true
 
    puts text                       # => 'text/plain'

--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -25,6 +25,7 @@ end
 #  puts text.ascii?                # => true
 #  puts text.obsolete?             # => false
 #  puts text.registered?           # => true
+#  puts text.provisional?          # => false
 #  puts text.complete?             # => true
 #
 #  puts text                       # => 'text/plain'
@@ -92,7 +93,7 @@ class MIME::Type
   end
 
   # The released version of the mime-types library.
-  VERSION = "3.3.1"
+  VERSION = "3.4.0"
 
   include Comparable
 
@@ -123,7 +124,7 @@ class MIME::Type
   # Yields the newly constructed +self+ object.
   def initialize(content_type) # :yields: self
     @friendly = {}
-    @obsolete = @registered = false
+    @obsolete = @registered = @provisional = false
     @preferred_extension = @docs = @use_instead = nil
     self.extensions = []
 
@@ -419,6 +420,14 @@ class MIME::Type
   attr_accessor :registered
   alias_method :registered?, :registered
 
+  # Indicates whether the MIME type's registration with IANA is provisional.
+  attr_accessor :provisional
+
+  # Indicates whether the MIME type's registration with IANA is provisional.
+  def provisional?
+    registered? && @provisional
+  end
+
   # MIME types can be specified to be sent across a network in particular
   # formats. This method returns +true+ when the MIME::Type encoding is set
   # to <tt>base64</tt>.
@@ -493,6 +502,7 @@ class MIME::Type
       end
     end
     coder["registered"] = registered?
+    coder["provisional"] = provisional? if provisional?
     coder["signature"] = signature? if signature?
     coder
   end
@@ -509,6 +519,7 @@ class MIME::Type
     self.preferred_extension = coder["preferred-extension"]
     self.obsolete = coder["obsolete"] || false
     self.registered = coder["registered"] || false
+    self.provisional = coder["provisional"] || false
     self.signature = coder["signature"]
     self.xrefs = coder["xrefs"] || {}
     self.use_instead = coder["use-instead"]

--- a/lib/mime/type/columnar.rb
+++ b/lib/mime/type/columnar.rb
@@ -35,8 +35,8 @@ class MIME::Type::Columnar < MIME::Type
   column :encoding, :encoding=
   column :docs, :docs=
   column :preferred_extension, :preferred_extension=
-  column :obsolete, :obsolete=, :obsolete?, :registered, :registered=,
-    :registered?, :signature, :signature=, :signature?, file: "flags"
+  column :obsolete, :obsolete=, :obsolete?, :registered, :registered=, :registered?, :signature, :signature=,
+    :signature?, :provisional, :provisional=, :provisional?, file: "flags"
   column :xrefs, :xrefs=, :xref_urls
   column :use_instead, :use_instead=
 

--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -61,6 +61,7 @@ require "mime/type"
 #  puts plaintext.ascii?                # => true
 #  puts plaintext.obsolete?             # => false
 #  puts plaintext.registered?           # => true
+#  puts plaintext.provisional?          # => false
 #  puts plaintext == 'text/plain'       # => true
 #  puts MIME::Type.simplified('x-appl/x-zip') # => 'appl/zip'
 #

--- a/lib/mime/types/_columnar.rb
+++ b/lib/mime/types/_columnar.rb
@@ -19,7 +19,7 @@ module MIME::Types::Columnar
   end
 
   # Load the first column data file (type and extensions).
-  def load_base_data(path) #:nodoc:
+  def load_base_data(path) # :nodoc:
     @__root__ = path
 
     each_file_line("content_type", false) do |line|
@@ -85,6 +85,7 @@ module MIME::Types::Columnar
       type.instance_variable_set(:@obsolete, flag(line.shift))
       type.instance_variable_set(:@registered, flag(line.shift))
       type.instance_variable_set(:@signature, flag(line.shift))
+      type.instance_variable_set(:@provisional, flag(line.shift))
     end
   end
 

--- a/lib/mime/types/container.rb
+++ b/lib/mime/types/container.rb
@@ -9,7 +9,7 @@ require "forwardable"
 # format (plus, a default of a mutable object resuls in a shared mess).
 # Hash#default_proc cannot be used without a wrapper because it prevents
 # Marshal serialization (and doesn't survive the round-trip).
-class MIME::Types::Container #:nodoc:
+class MIME::Types::Container # :nodoc:
   extend Forwardable
 
   def initialize(hash = {})

--- a/lib/mime/types/loader.rb
+++ b/lib/mime/types/loader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# -*- ruby encoding: utf-8 -*-
-
 ##
 module MIME; end
 

--- a/lib/mime/types/logger.rb
+++ b/lib/mime/types/logger.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# -*- ruby encoding: utf-8 -*-
-
 require "logger"
 
 ##
@@ -14,8 +12,8 @@ module MIME
       attr_accessor :logger
     end
 
-    class WarnLogger < ::Logger #:nodoc:
-      class WarnLogDevice < ::Logger::LogDevice #:nodoc:
+    class WarnLogger < ::Logger # :nodoc:
+      class WarnLogDevice < ::Logger::LogDevice # :nodoc:
         def initialize(*)
         end
 

--- a/mime-types.gemspec
+++ b/mime-types.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: mime-types 3.3.1 ruby lib
+# stub: mime-types 3.4.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "mime-types".freeze
-  s.version = "3.3.1"
+  s.version = "3.4.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/mime-types/ruby-mime-types/issues", "changelog_uri" => "https://github.com/mime-types/ruby-mime-types/blob/master/History.md", "homepage_uri" => "https://github.com/mime-types/ruby-mime-types/", "source_code_uri" => "https://github.com/mime-types/ruby-mime-types/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2021-06-02"
+  s.date = "2021-11-15"
   s.description = "The mime-types library provides a library and registry for information about\nMIME content type definitions. It can be used to determine defined filename\nextensions for MIME types, or to use filename extensions to look up the likely\nMIME type definitions.\n\nVersion 3.0 is a major release that requires Ruby 2.0 compatibility and removes\ndeprecated functions. The columnar registry format introduced in 2.6 has been\nmade the primary format; the registry data has been extracted from this library\nand put into {mime-types-data}[https://github.com/mime-types/mime-types-data].\nAdditionally, mime-types is now licensed exclusively under the MIT licence and\nthere is a code of conduct in effect. There are a number of other smaller\nchanges described in the History file.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
     s.add_development_dependency(%q<minitest-hooks>.freeze, ["~> 1.4"])
     s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14.0"])
-    s.add_development_dependency(%q<psych>.freeze, ["~> 3.0"])
     s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.7"])
     s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
     s.add_development_dependency(%q<hoe>.freeze, ["~> 3.23"])
@@ -55,7 +54,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
     s.add_dependency(%q<minitest-hooks>.freeze, ["~> 1.4"])
     s.add_dependency(%q<rake>.freeze, [">= 10.0", "< 14.0"])
-    s.add_dependency(%q<psych>.freeze, ["~> 3.0"])
     s.add_dependency(%q<simplecov>.freeze, ["~> 0.7"])
     s.add_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
     s.add_dependency(%q<hoe>.freeze, ["~> 3.23"])

--- a/support/deps.rb
+++ b/support/deps.rb
@@ -1,0 +1,42 @@
+require "net/http"
+require "json"
+
+class Deps
+  def self.run(args)
+    new.run(args)
+  end
+
+  def run(args)
+    deps = rubygems_get(gem_name: "mime-types", endpoint: "reverse_dependencies")
+    weighted_deps = {}
+
+    deps.each do |name|
+      downloads = gem_downloads(name)
+      weighted_deps[name] = downloads if downloads
+    rescue => e
+      puts "#{name} #{e.message}"
+    end
+
+    weighted_deps
+      .sort { |(_k1, v1), (_k2, v2)| v2 <=> v1 }
+      .first(args.number || 50)
+      .each_with_index do |(k, v), i|
+      puts "#{i}) #{k}: #{v}"
+    end
+  end
+
+  private
+
+  def rubygems_get(gem_name: "", endpoint: "")
+    path = File.join("/api/v1/gems/", gem_name, endpoint).chomp("/") + ".json"
+    Net::HTTP.start("rubygems.org", use_ssl: true) do |http|
+      JSON.parse(http.get(path).body)
+    end
+  end
+
+  def gem_downloads(name)
+     rubygems_get(gem_name: name)["downloads"]
+  rescue => e
+    puts "#{name} #{e.message}"
+  end
+end

--- a/test/test_mime_type.rb
+++ b/test/test_mime_type.rb
@@ -461,12 +461,23 @@ describe MIME::Type do
   end
 
   describe "#to_json" do
-    let(:expected) {
+    let(:expected_1) {
       '{"content-type":"a/b","encoding":"base64","registered":false}'
+    }
+    let(:expected_2) {
+      '{"content-type":"a/b","encoding":"base64","registered":true,"provisional":true}'
     }
 
     it "converts to JSON when requested" do
-      assert_equal expected, mime_type("a/b").to_json
+      assert_equal expected_1, mime_type("a/b").to_json
+    end
+
+    it "converts to JSON with provisional when requested" do
+      type = mime_type("a/b") do |t|
+        t.registered = true
+        t.provisional = true
+      end
+      assert_equal expected_2, type.to_json
     end
   end
 


### PR DESCRIPTION
- 1 minor enhancement:

  - Added a new field to `MIME::Type` for checking provisional registrations
    from IANA.

- Documentation:

  - Kevin Menard synced the documentation so that all examples are correct
    [#153].

- Administrivia:

  - Added Ruby 3.0 to the CI test matrix. Added `windows/jruby` to the
    CI exclusion list; it refuses to run successfully.
  - Removed the Travis CI configuration and changed it to Github Workflows
    [#150]. Removed Coveralls configuration.
  - Igor Victor added TruffleRuby to the Travis CI configuration [#149].
  - Koichi ITO loosened an excessively tight dependency [#147].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/157)
<!-- Reviewable:end -->
