### PR TITLE
Fix invalid syntax for < Ruby 2.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.4.1 / 2021-11-16
+
+- 1 bugfix:
+
+  - Fixed a Ruby &lt; 2.3 incompatibility introduced by the use of standardrb,
+    where `<<-` heredocs were converted to `<<~` heredocs. These have been
+    reverted back to `<<-` with the indentation kept and a `.strip` call
+    to prevent excess whitespace.
+
 ## 3.4.0 / 2021-11-15
 
 - 1 minor enhancement:

--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -93,7 +93,7 @@ class MIME::Type
   end
 
   # The released version of the mime-types library.
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 
   include Comparable
 

--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -187,7 +187,7 @@ class MIME::Types
   # truthy value to suppress that warning.
   def add_type(type, quiet = false)
     if !quiet && @type_variants[type.simplified].include?(type)
-      MIME::Types.logger.warn <<~WARNING
+      MIME::Types.logger.warn <<-WARNING.chomp.strip
         Type #{type} is already registered as a variant of #{type.simplified}.
       WARNING
     end

--- a/lib/mime/types/cache.rb
+++ b/lib/mime/types/cache.rb
@@ -22,13 +22,13 @@ class << MIME::Types::Cache
     if cache.version == MIME::Types::Data::VERSION
       Marshal.load(cache.data)
     else
-      MIME::Types.logger.warn <<~WARNING.chomp
+      MIME::Types.logger.warn <<-WARNING.chomp.strip
         Could not load MIME::Types cache: invalid version
       WARNING
       nil
     end
   rescue => e
-    MIME::Types.logger.warn <<~WARNING.chomp
+    MIME::Types.logger.warn <<-WARNING.chomp.strip
       Could not load MIME::Types cache: #{e}
     WARNING
     nil

--- a/lib/mime/types/deprecations.rb
+++ b/lib/mime/types/deprecations.rb
@@ -25,7 +25,7 @@ module MIME
                 else
                   message
         end
-      MIME::Types.logger.warn <<~WARNING.chomp
+      MIME::Types.logger.warn <<-WARNING.chomp.strip
         #{caller(2..2).first}: #{klass}#{level}#{sym} is deprecated #{message}.
       WARNING
 

--- a/lib/mime/types/registry.rb
+++ b/lib/mime/types/registry.rb
@@ -45,7 +45,7 @@ class << MIME::Types
   def lazy_load?
     return unless ENV.key?("RUBY_MIME_TYPES_LAZY_LOAD")
 
-    MIME::Types.logger.warn <<~WARNING.chomp
+    MIME::Types.logger.warn <<-WARNING.chomp.strip
       Lazy loading ($RUBY_MIME_TYPES_LAZY_LOAD) is deprecated and will be removed.
     WARNING
 

--- a/mime-types.gemspec
+++ b/mime-types.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: mime-types 3.4.0 ruby lib
+# stub: mime-types 3.4.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "mime-types".freeze
-  s.version = "3.4.0"
+  s.version = "3.4.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/mime-types/ruby-mime-types/issues", "changelog_uri" => "https://github.com/mime-types/ruby-mime-types/blob/master/History.md", "homepage_uri" => "https://github.com/mime-types/ruby-mime-types/", "source_code_uri" => "https://github.com/mime-types/ruby-mime-types/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2021-11-15"
+  s.date = "2021-11-16"
   s.description = "The mime-types library provides a library and registry for information about\nMIME content type definitions. It can be used to determine defined filename\nextensions for MIME types, or to use filename extensions to look up the likely\nMIME type definitions.\n\nVersion 3.0 is a major release that requires Ruby 2.0 compatibility and removes\ndeprecated functions. The columnar registry format introduced in 2.6 has been\nmade the primary format; the registry data has been extracted from this library\nand put into {mime-types-data}[https://github.com/mime-types/mime-types-data].\nAdditionally, mime-types is now licensed exclusively under the MIT licence and\nthere is a code of conduct in effect. There are a number of other smaller\nchanges described in the History file.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]

--- a/support/deps.rb
+++ b/support/deps.rb
@@ -35,7 +35,7 @@ class Deps
   end
 
   def gem_downloads(name)
-     rubygems_get(gem_name: name)["downloads"]
+    rubygems_get(gem_name: name)["downloads"]
   rescue => e
     puts "#{name} #{e.message}"
   end


### PR DESCRIPTION
Fixed a Ruby &lt; 2.3 incompatibility introduced by the use of standardrb, where `<<-` heredocs were converted to `<<~` heredocs. These have been reverted back to `<<-` with the indentation kept and a `.strip` call to prevent excess whitespace.

Resolves #159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/160)
<!-- Reviewable:end -->
