### PR TITLE
Clean up Travis CI

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -25,11 +25,11 @@ The mime-types registry is no longer contained in mime-types, but in
 
 mime-types uses Ryan Davis’s [Hoe][] to manage the release process, and it adds
 a number of rake tasks. You will mostly be interested in `rake`, which runs the
-tests the same way that `rake test` or `rake travis` will do.
+tests the same way that `rake test` will do.
 
 To assist with the installation of the development dependencies for
 mime-types, I have provided the simplest possible Gemfile pointing to the
-(generated) `mime-types.gemspec` file. This will permit you to do `bundle install` to get the development dependencies. If you aleady have `hoe`
+(generated) `mime-types.gemspec` file. This will permit you to do `bundle install` to get the development dependencies. If you already have `hoe`
 installed, you can accomplish the same thing with `rake newb`.
 
 This task will install any missing dependencies, run the tests/specs, and

--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@ code :: https://github.com/mime-types/ruby-mime-types/
 bugs :: https://github.com/mime-types/ruby-mime-types/issues
 rdoc :: http://rdoc.info/gems/mime-types/
 clog :: https://github.com/mime-types/ruby-mime-types/blob/master/History.md
-continuous integration :: {<img src="https://travis-ci.org/mime-types/ruby-mime-types.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/mime-types/ruby-mime-types]
+continuous integration :: {<img src="https://github.com/mime-types/ruby-mime-types/actions/workflows/ci.yml/badge.svg" alt="Build Status" />}[https://github.com/mime-types/ruby-mime-types/actions/workflows/ci.yml]
 test coverage :: {<img src="https://coveralls.io/repos/mime-types/ruby-mime-types/badge.svg?branch=master&service=github" alt="Coverage Status" />}[https://coveralls.io/github/mime-types/ruby-mime-types?branch=master]
 
 == Description


### PR DESCRIPTION
Migrating CI from Travis CI to GitHub Actions is done in #150.
This PR is a follow-up to that.

- Replace CI status badge from Travis CI to GitHub Actions
- Remove reference to `rake travis`
- Fix tiny typo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/164)
<!-- Reviewable:end -->
