### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
           - head
           - debug
           - mingw
@@ -61,7 +62,7 @@ jobs:
       (startsWith(matrix.ruby, 'jruby') && matrix.os == 'windows')
       }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.
And includes the following:
- Bump actions/checkout from v2 to v3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/165)
<!-- Reviewable:end -->
