### PR TITLE
Define MIME::Type#hash

### DIFF
--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -224,6 +224,32 @@ class MIME::Type
     other.is_a?(MIME::Type) && (self == other)
   end
 
+  # Returns a hash based on the #simplified value.
+  #
+  # This maintains the invariant that two #eql? instances must have the same
+  # #hash (although having the same #hash does *not* imply that the objects are
+  # #eql?).
+  #
+  # To see why, suppose a MIME::Type instance +a+ is compared to another object
+  # +b+, and that <code>a.eql?(b)</code> is true. By the definition of #eql?,
+  # we know the following:
+  #
+  # 1. +b+ is a MIME::Type instance itself.
+  # 2. <code>a == b</code> is true.
+  #
+  # Due to the first point, we know that +b+ should respond to the #simplified
+  # method. Thus, per the definition of #<=>, we know that +a.simplified+ must
+  # be equal to +b.simplified+, as compared by the <=> method corresponding to
+  # +a.simplified+.
+  #
+  # Presumably, if <code>a.simplified <=> b.simplified</code> is +0+, then
+  # +a.simplified+ has the same hash as +b.simplified+. So we assume it's
+  # suitable for #hash to delegate to #simplified in service of the #eql?
+  # invariant.
+  def hash
+    simplified.hash
+  end
+
   # Returns the whole MIME content-type string.
   #
   # The content type is a presentation value from the MIME type registry and

--- a/test/test_mime_type.rb
+++ b/test/test_mime_type.rb
@@ -266,7 +266,27 @@ describe MIME::Type do
     end
 
     it "is true for an equivalent MIME::Type" do
-      assert text_plain, mime_type("text/Plain")
+      assert text_plain.eql?(mime_type("text/Plain"))
+    end
+
+    it "is true for an equivalent subclass of MIME::Type" do
+      subclass = Class.new(MIME::Type)
+      assert text_plain.eql?(subclass.new("text/plain"))
+    end
+  end
+
+  describe "#hash" do
+    it "is the same between #eql? MIME::Type instances" do
+      assert_equal text_plain.hash, mime_type("text/plain").hash
+    end
+
+    it "is the same between #eql? MIME::Type instances of different classes" do
+      subclass = Class.new(MIME::Type)
+      assert_equal text_plain.hash, subclass.new("text/plain").hash
+    end
+
+    it "uses the #simplified value" do
+      assert_equal text_plain.hash, mime_type("text/Plain").hash
     end
   end
 


### PR DESCRIPTION
Fixes #166. See that issue for the relevant context.

Upon studying the definition of `MIME::Type#eql?`, I determined that we shouldn't include `self.class` in the hash. `#eql?` uses an `#is_a?` check, which will succeed even on subclasses of `MIME::Type`. So `#eql?` doesn't require `self` and `other` be of the exact same class. If we were to include `self.class` in the hash, then it would erroneously make the hashes different for two `#eql?` objects of different classes (since different classes generally hash to different values). I added an extra test around `MIME::Type#eql?` to codify this behavior. While I was in there, I also fixed a typo in an existing `MIME::Type#eql?` test. 😅 

Note that there aren't many generic tests we can make around `#hash` itself. Even two distinct `MIME::Type` instances could still hash to the same value, in principle. So there are only really tests around instances that should be `#eql?` to each other.

One clue we have that this PR addresses the randomness of warnings seen in #163 is when I run `rake` with/without these changes locally. :)

On main, I see no warnings about the duplicate `application/netcdf` data, because the `Set` treats the two instances as distinct (unless we get lucky, which has also happened to me intermittently):

<details>
<summary>Without hash definition</summary>

```console
$ git branch
  define-mime-type-hash
* main
$ rake
Run options: --seed 63590

# Running:

...................................................................................................................................................

Finished in 2.143452s, 68.5810 runs/s, 137.1619 assertions/s.

147 runs, 294 assertions, 0 failures, 0 errors, 0 skips
rm -rf doc
rm -r pkg
```
</details>

On the topic branch, I see _all the warnings_ ‼️  now that the two instances hash the same:

<details>
<summary>With hash definition</summary>

```console
$ git branch
* define-mime-type-hash
  main
$ rake
Type application/netcdf is already registered as a variant of application/netcdf.
Run options: --seed 24550

# Running:

.......Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
............................Type application/netcdf is already registered as a variant of application/netcdf.
.................Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
................Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
........Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.Type application/netcdf is already registered as a variant of application/netcdf.
.........Type application/netcdf is already registered as a variant of application/netcdf.
Type application/netcdf is already registered as a variant of application/netcdf.
...............................................

Finished in 3.228527s, 46.7706 runs/s, 92.3022 assertions/s.

151 runs, 298 assertions, 0 failures, 0 errors, 0 skips
rm -rf doc
rm -r pkg
```
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/167)
<!-- Reviewable:end -->
