### PR TITLE
Change "...is already registered as a variant..." message to `DEBUG` level

### DIFF
--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -187,7 +187,7 @@ class MIME::Types
   # truthy value to suppress that warning.
   def add_type(type, quiet = false)
     if !quiet && @type_variants[type.simplified].include?(type)
-      MIME::Types.logger.warn <<-WARNING.chomp.strip
+      MIME::Types.logger.debug <<-WARNING.chomp.strip
         Type #{type} is already registered as a variant of #{type.simplified}.
       WARNING
     end


### PR DESCRIPTION
A simpler way to solve https://github.com/mime-types/mime-types-data/pull/50.

> IMO the problem is, the library shows a warning message to the wrong audience (application developers). It's not understandable to app devs, not marked with its provenance (source lib name), and finally, app devs have no way to resolve it.

> Instead, the message seems aimed at mime-types-data library developers.

This PR sends the message to the proper audience by using the `DEBUG` log level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/170)
<!-- Reviewable:end -->
