### PR TITLE
Various upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,56 +19,47 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - macos-latest
+          - ubuntu-20.04
         ruby:
-          - '2.4'
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
           - head
-          - debug
-          - mingw
-          - mswin
           - jruby
           - jruby-head
           - truffleruby
           - truffleruby-head
-        exclude:
-          - os: macos
+          - truffleruby+graalvm
+          - truffleruby+graalvm-head
+        include:
+          - ruby: head
+            continue-on-error: true
+          - ruby: jruby-head
+            continue-on-error: true
+          - os: windows-latest
             ruby: mingw
-          - os: macos
+          - os: windows-latest
             ruby: mswin
-          - os: ubuntu
-            ruby: mingw
-          - os: ubuntu
-            ruby: mswin
-          - os: windows
-            ruby: debug
-          - os: windows
+          - os: windows-latest
             ruby: jruby
-          - os: windows
-            ruby: jruby-head
-          - os: windows
-            ruby: truffleruby
-          - os: windows
-            ruby: truffleruby-head
-    runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{
-      endsWith(matrix.ruby, 'head') ||
-      matrix.ruby == 'debug' ||
-      (startsWith(matrix.ruby, 'jruby') && matrix.os == 'windows')
-      }}
+            continue-on-error: true
+          - os: ubuntu-22.04
+            ruby: head
+          - os: ubuntu-22.04
+            ruby: '3.1'
+          - os: ubuntu-22.04
+            ruby: '3.2'
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error || false }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # 'bundle install' and cache
-      - name: Run tests
-        run: bundle exec ruby -S rake test --trace
+          rubygems: ${{ matrix.rubygems || 'latest' }}
+          bundler: 2
+          bundler-cache: true
+      - run: bundle exec ruby -S rake test --trace

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
 parallel: true
-ruby_version: 2.0
+ruby_version: 2.3
 ignore:
   - 'mime-types.gemspec'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ source "https://rubygems.org/"
 
 gem "mime-types-data", path: "../mime-types-data" if ENV["DEV"]
 
+gem "debug", platforms: [:mri_31]
+
 gemspec
 
 # vim: syntax=ruby

--- a/History.md
+++ b/History.md
@@ -7,6 +7,23 @@
   - Added a definition of `MIME::Type#hash`. Contributed by Alex Vondrak in
     [#167][], fixing [#166][].
 
+- Dependency and CI updates:
+
+  - Update the .github/workflows/ci.yml workflow to test Ruby 3.2 and more
+    reliably test certain combinations rather than depending on exclusions.
+
+  - Change `.standard.yml` configuration to format for Ruby 2.3 as certain files
+    are not properly detected with Ruby 2.0.
+
+    - Change from `hoe-git` to `hoe-git2` to support Hoe version 4.
+
+    - Apply `standardrb --fix`.
+
+    - The above changes have resulted in the Soft deprecation of Ruby versions
+      below 2.6. Any errors reported for Ruby versions 2.0, 2.1, 2.2, 2.3, 2.4,
+      and 2.5 will be resolved, but maintaining CI for these versions is
+      unsustainable.
+
 ## 3.4.1 / 2021-11-16
 
 - 1 bugfix:

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,3 +1,4 @@
+.standard.yml
 Code-of-Conduct.md
 Contributing.md
 History.md

--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,6 @@ Hoe.plugin :email unless ENV["CI"]
 
 spec = Hoe.spec "mime-types" do
   developer("Austin Ziegler", "halostatue@gmail.com")
-  self.need_tar = true
 
   require_ruby_version ">= 2.0"
 
@@ -58,17 +57,18 @@ spec = Hoe.spec "mime-types" do
 
   extra_deps << ["mime-types-data", "~> 3.2015"]
 
+  extra_dev_deps << ["hoe", ">= 3.0", "< 5"]
   extra_dev_deps << ["hoe-doofus", "~> 1.0"]
   extra_dev_deps << ["hoe-gemspec2", "~> 1.1"]
-  extra_dev_deps << ["hoe-git", "~> 1.6"]
+  extra_dev_deps << ["hoe-git2", "~> 1.7"]
   extra_dev_deps << ["hoe-rubygems", "~> 1.0"]
-  extra_dev_deps << ["standard", "~> 1.0"]
-  extra_dev_deps << ["minitest", "~> 5.4"]
+  extra_dev_deps << ["minitest", "~> 5.0"]
   extra_dev_deps << ["minitest-autotest", "~> 1.0"]
-  extra_dev_deps << ["minitest-focus", "~> 1.0"]
   extra_dev_deps << ["minitest-bonus-assertions", "~> 3.0"]
+  extra_dev_deps << ["minitest-focus", "~> 1.0"]
   extra_dev_deps << ["minitest-hooks", "~> 1.4"]
   extra_dev_deps << ["rake", ">= 10.0", "< 14.0"]
+  extra_dev_deps << ["standard", "~> 1.0"]
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.0")
     extra_dev_deps << ["simplecov", "~> 0.7"]
@@ -235,9 +235,7 @@ namespace :convert do
 
       file mark => [rdoc, :setup] do |t|
         puts "#{rdoc} => #{mark}"
-        File.open(t.name, "wb") { |target|
-          target.write @doc_converter.convert(IO.read(t.prerequisites.first))
-        }
+        File.binwrite(t.name, @doc_converter.convert(IO.read(t.prerequisites.first)))
       end
 
       CLEAN.add mark

--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -364,7 +364,7 @@ class MIME::Type
 
   # Returns the default encoding for the MIME::Type based on the media type.
   def default_encoding
-    @media_type == "text" ? "quoted-printable" : "base64"
+    (@media_type == "text") ? "quoted-printable" : "base64"
   end
 
   ##

--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -125,12 +125,12 @@ class MIME::Types
   def [](type_id, complete: false, registered: false)
     matches =
       case type_id
-              when MIME::Type
-                @type_variants[type_id.simplified]
-              when Regexp
-                match(type_id)
-              else
-                @type_variants[MIME::Type.simplified(type_id)]
+      when MIME::Type
+        @type_variants[type_id.simplified]
+      when Regexp
+        match(type_id)
+      else
+        @type_variants[MIME::Type.simplified(type_id)]
       end
 
     prune_matches(matches, complete, registered).sort { |a, b|

--- a/lib/mime/types/cache.rb
+++ b/lib/mime/types/cache.rb
@@ -49,10 +49,6 @@ class << MIME::Types::Cache
 
     types ||= MIME::Types.send(:__types__)
 
-    File.open(cache_file, "wb") do |f|
-      f.write(
-        Marshal.dump(new(MIME::Types::Data::VERSION, Marshal.dump(types)))
-      )
-    end
+    File.binwrite(cache_file, Marshal.dump(new(MIME::Types::Data::VERSION, Marshal.dump(types))))
   end
 end

--- a/lib/mime/types/deprecations.rb
+++ b/lib/mime/types/deprecations.rb
@@ -10,20 +10,20 @@ module MIME
     def self.deprecated(klass, sym, message = nil, &block) # :nodoc:
       level =
         case klass
-              when Class, Module
-                "."
-              else
-                klass = klass.class
-                "#"
+        when Class, Module
+          "."
+        else
+          klass = klass.class
+          "#"
         end
       message =
         case message
-                when :private, :protected
-                  "and will be #{message}"
-                when nil
-                  "and will be removed"
-                else
-                  message
+        when :private, :protected
+          "and will be #{message}"
+        when nil
+          "and will be removed"
+        else
+          message
         end
       MIME::Types.logger.warn <<-WARNING.chomp.strip
         #{caller(2..2).first}: #{klass}#{level}#{sym} is deprecated #{message}.

--- a/mime-types.gemspec
+++ b/mime-types.gemspec
@@ -9,53 +9,33 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/mime-types/ruby-mime-types/issues", "changelog_uri" => "https://github.com/mime-types/ruby-mime-types/blob/master/History.md", "homepage_uri" => "https://github.com/mime-types/ruby-mime-types/", "source_code_uri" => "https://github.com/mime-types/ruby-mime-types/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2021-11-16"
+  s.date = "2023-02-17"
   s.description = "The mime-types library provides a library and registry for information about\nMIME content type definitions. It can be used to determine defined filename\nextensions for MIME types, or to use filename extensions to look up the likely\nMIME type definitions.\n\nVersion 3.0 is a major release that requires Ruby 2.0 compatibility and removes\ndeprecated functions. The columnar registry format introduced in 2.6 has been\nmade the primary format; the registry data has been extracted from this library\nand put into {mime-types-data}[https://github.com/mime-types/mime-types-data].\nAdditionally, mime-types is now licensed exclusively under the MIT licence and\nthere is a code of conduct in effect. There are a number of other smaller\nchanges described in the History file.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]
-  s.files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "lib/mime-types.rb".freeze, "lib/mime/type.rb".freeze, "lib/mime/type/columnar.rb".freeze, "lib/mime/types.rb".freeze, "lib/mime/types/_columnar.rb".freeze, "lib/mime/types/cache.rb".freeze, "lib/mime/types/columnar.rb".freeze, "lib/mime/types/container.rb".freeze, "lib/mime/types/deprecations.rb".freeze, "lib/mime/types/full.rb".freeze, "lib/mime/types/loader.rb".freeze, "lib/mime/types/logger.rb".freeze, "lib/mime/types/registry.rb".freeze, "test/bad-fixtures/malformed".freeze, "test/fixture/json.json".freeze, "test/fixture/old-data".freeze, "test/fixture/yaml.yaml".freeze, "test/minitest_helper.rb".freeze, "test/test_mime_type.rb".freeze, "test/test_mime_types.rb".freeze, "test/test_mime_types_cache.rb".freeze, "test/test_mime_types_class.rb".freeze, "test/test_mime_types_lazy.rb".freeze, "test/test_mime_types_loader.rb".freeze]
+  s.files = [".standard.yml".freeze, "Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "lib/mime-types.rb".freeze, "lib/mime/type.rb".freeze, "lib/mime/type/columnar.rb".freeze, "lib/mime/types.rb".freeze, "lib/mime/types/_columnar.rb".freeze, "lib/mime/types/cache.rb".freeze, "lib/mime/types/columnar.rb".freeze, "lib/mime/types/container.rb".freeze, "lib/mime/types/deprecations.rb".freeze, "lib/mime/types/full.rb".freeze, "lib/mime/types/loader.rb".freeze, "lib/mime/types/logger.rb".freeze, "lib/mime/types/registry.rb".freeze, "test/bad-fixtures/malformed".freeze, "test/fixture/json.json".freeze, "test/fixture/old-data".freeze, "test/fixture/yaml.yaml".freeze, "test/minitest_helper.rb".freeze, "test/test_mime_type.rb".freeze, "test/test_mime_types.rb".freeze, "test/test_mime_types_cache.rb".freeze, "test/test_mime_types_class.rb".freeze, "test/test_mime_types_lazy.rb".freeze, "test/test_mime_types_loader.rb".freeze]
   s.homepage = "https://github.com/mime-types/ruby-mime-types/".freeze
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
-  s.rubygems_version = "3.1.6".freeze
+  s.rubygems_version = "3.4.7".freeze
   s.summary = "The mime-types library provides a library and registry for information about MIME content type definitions".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<mime-types-data>.freeze, ["~> 3.2015"])
-    s.add_development_dependency(%q<minitest>.freeze, ["~> 5.14"])
-    s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
-    s.add_development_dependency(%q<minitest-hooks>.freeze, ["~> 1.4"])
-    s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14.0"])
-    s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.7"])
-    s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.23"])
-  else
-    s.add_dependency(%q<mime-types-data>.freeze, ["~> 3.2015"])
-    s.add_dependency(%q<minitest>.freeze, ["~> 5.14"])
-    s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-focus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
-    s.add_dependency(%q<minitest-hooks>.freeze, ["~> 1.4"])
-    s.add_dependency(%q<rake>.freeze, [">= 10.0", "< 14.0"])
-    s.add_dependency(%q<simplecov>.freeze, ["~> 0.7"])
-    s.add_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.23"])
-  end
+  s.add_runtime_dependency(%q<mime-types-data>.freeze, ["~> 3.2015"])
+  s.add_development_dependency(%q<minitest>.freeze, ["~> 5.17"])
+  s.add_development_dependency(%q<hoe>.freeze, [">= 3.0", "< 5"])
+  s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
+  s.add_development_dependency(%q<hoe-git2>.freeze, ["~> 1.7"])
+  s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
+  s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<minitest-hooks>.freeze, ["~> 1.4"])
+  s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14.0"])
+  s.add_development_dependency(%q<standard>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.7"])
+  s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
 end

--- a/support/deps.rb
+++ b/support/deps.rb
@@ -11,10 +11,12 @@ class Deps
     weighted_deps = {}
 
     deps.each do |name|
-      downloads = gem_downloads(name)
-      weighted_deps[name] = downloads if downloads
-    rescue => e
-      puts "#{name} #{e.message}"
+      begin
+        downloads = gem_downloads(name)
+        weighted_deps[name] = downloads if downloads
+      rescue => e
+        puts "#{name} #{e.message}"
+      end
     end
 
     weighted_deps

--- a/test/test_mime_types_cache.rb
+++ b/test/test_mime_types_cache.rb
@@ -67,7 +67,7 @@ describe MIME::Types::Cache do
     it "outputs an error when there is a marshal file incompatibility" do
       MIME::Types::Cache.save
       data = File.binread(@cache_file).reverse
-      File.open(@cache_file, "wb") { |f| f.write(data) }
+      File.binwrite(@cache_file, data)
       MIME::Types.instance_variable_set(:@__types__, nil)
       assert_output "", /incompatible marshal file format/ do
         MIME::Types["text/html"]


### PR DESCRIPTION
- Update the .github/workflows/ci.yml workflow to test Ruby 3.2 and more reliably test certain combinations rather than depending on exclusions.

- Change `.standard.yml` configuration to format for Ruby 2.3 as certain files are not properly detected with Ruby 2.0.

- Change from `hoe-git` to `hoe-git2` to support Hoe version 4.

- Apply `standardrb --fix`.

- Update other dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/173)
<!-- Reviewable:end -->
