### PR TITLE
Handle `\n` in MIME::Types.type_for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
           - jruby
           - jruby-head
           - truffleruby
-          - truffleruby-head
           - truffleruby+graalvm
-          - truffleruby+graalvm-head
         include:
           - ruby: head
             continue-on-error: true
@@ -45,6 +43,13 @@ jobs:
             ruby: '3.1'
           - os: ubuntu-22.04
             ruby: '3.2'
+          - os: ubuntu-22.04
+            ruby: truffleruby+graalvm-head
+            continue-on-error: true
+          - os: ubuntu-22.04
+            ruby: truffleruby-head
+            continue-on-error: true
+
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error || false }}
     steps:

--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.5.1 / 2023-08-21
+
+- 1 bug fix:
+
+  - Better handle possible line-termination strings (legal in Unix filenames)
+    such as `\n` in `MIME::Types.type_for`. Reported by ooooooo-q in [#177][],
+    resolved in [#178][].
+
 ## 3.5.0 / 2023-08-07
 
 - 1 minor enhancement:
@@ -304,6 +312,8 @@
 [#166]: https://github.com/mime-types/ruby-mime-types/issues/166
 [#167]: https://github.com/mime-types/ruby-mime-types/pull/167
 [#170]: https://github.com/mime-types/ruby-mime-types/pull/170
+[#177]: https://github.com/mime-types/ruby-mime-types/issues/177
+[#178]: https://github.com/mime-types/ruby-mime-types/pull/178
 [code-of-conduct.md]: Code-of-Conduct_md.html
 [contributor covenant]: http://contributor-covenant.org
 [mime-types-data]: https://github.com/mime-types/mime-types-data

--- a/lib/mime/type.rb
+++ b/lib/mime/type.rb
@@ -93,7 +93,7 @@ class MIME::Type
   end
 
   # The released version of the mime-types library.
-  VERSION = "3.5.0"
+  VERSION = "3.5.1"
 
   include Comparable
 

--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -152,7 +152,7 @@ class MIME::Types
   #     => [application/xml, image/gif, text/xml]
   def type_for(filename)
     Array(filename).flat_map { |fn|
-      @extension_index[fn.chomp.downcase[/\.?([^.]*?)$/, 1]]
+      @extension_index[fn.chomp.downcase[/\.?([^.]*?)\z/m, 1]]
     }.compact.inject(Set.new, :+).sort { |a, b|
       a.priority_compare(b)
     }

--- a/test/test_mime_types.rb
+++ b/test/test_mime_types.rb
@@ -159,6 +159,10 @@ describe MIME::Types do
       plain_text.add_extensions("xtxt")
       assert_includes mime_types.type_for("xtxt"), "text/plain"
     end
+
+    it "handles newline characters correctly" do
+      assert_includes mime_types.type_for("test.pdf\n.txt"), "text/plain"
+    end
   end
 
   describe "#count" do

--- a/test/test_mime_types_class.rb
+++ b/test/test_mime_types_class.rb
@@ -100,6 +100,11 @@ describe MIME::Types, "registry" do
       plain_text.add_extensions("xtxt")
       assert_includes MIME::Types.type_for("xtxt"), "text/plain"
     end
+
+    it "handles newline characters correctly" do
+      assert_includes MIME::Types.type_for("test.pdf\n.txt"), "text/plain"
+      assert_includes MIME::Types.type_for("test.txt\n.pdf"), "application/pdf"
+    end
   end
 
   describe ".count" do


### PR DESCRIPTION
Resolves #177.

Better handle possible line-termination strings (legal in Unix filenames) such as `\n` in `MIME::Types.type_for`. Reported by @ooooooo-q.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mime-types/ruby-mime-types/178)
<!-- Reviewable:end -->
