### PR TITLE
fix changelog uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT / 2025-MM-DD
+
+- Updated the reference to the changelog in the README, fixing RubyGems metadata on the next release. Fixed in [#189][pull-189] by nna774.
+
 ## 3.6.1 / 2025-03-15
 
 - Restructure project structure to be more consistent with mime-types-data.
@@ -367,6 +371,7 @@ there are some validation changes and updated code with formatting.
 [pull-178]: https://github.com/mime-types/ruby-mime-types/pull/178
 [pull-179]: https://github.com/mime-types/ruby-mime-types/pull/179
 [pull-180]: https://github.com/mime-types/ruby-mime-types/pull/180
+[pull-189]: https://github.com/mime-types/ruby-mime-types/pull/189
 [pull-79]: https://github.com/mime-types/ruby-mime-types/pull/79
 [pull-84]: https://github.com/mime-types/ruby-mime-types/pull/84
 [pull-85]: https://github.com/mime-types/ruby-mime-types/pull/85

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ Thanks to everyone else who has contributed to mime-types over the years:
 - Martin d'Allens
 - Masato Nakamura
 - Mauricio Linhares
+- Nana Kugayama
 - Nicholas La Roux
 - Nicolas Leger
 - nycvotes-dev

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - code :: https://github.com/mime-types/ruby-mime-types/
 - rdoc :: http://rdoc.info/gems/mime-types/
 - changelog ::
-  https://github.com/mime-types/ruby-mime-types/blob/master/History.md
+  https://github.com/mime-types/ruby-mime-types/blob/main/CHANGELOG.md
 - continuous integration ::
   {<img src="https://github.com/mime-types/ruby-mime-types/actions/workflows/ci.yml/badge.svg" alt="Build Status" />}[https://github.com/mime-types/ruby-mime-types/actions/workflows/ci.yml]
 - test coverage ::


### PR DESCRIPTION
In the pull request at https://github.com/mime-types/ruby-mime-types/pull/184, the changelog URI was moved from History.md to CHANGELOG.md. As a result, I encountered a 404 error when clicking on the changelog link at https://rubygems.org/gems/mime-types.
