### PR TITLE
Add test for application/msword mime-type detection with doc extension

### DIFF
--- a/test/test_mime_types.rb
+++ b/test/test_mime_types.rb
@@ -13,6 +13,7 @@ describe MIME::Types do
         MIME::Type.new("content-type" => "application/x-www-form-urlencoded", "registered" => true),
         MIME::Type.new("content-type" => "application/x-gzip", "extensions" => %w[gz]),
         MIME::Type.new("content-type" => "application/gzip", "extensions" => "gz", "registered" => true),
+        MIME::Type.new("content-type" => "application/msword", "extensions" => %w[doc]),
         *MIME::Types.type_for("foo.webm")
       )
     }
@@ -133,6 +134,11 @@ describe MIME::Types do
     it "finds all types for a given extension" do
       assert_equal %w[application/gzip application/x-gzip],
         mime_types.type_for("gz")
+    end
+
+    it "returns the correct MIME type for a .doc file" do
+      type = MIME::Types.type_for('test.doc').first
+      assert_equal 'application/msword', type.to_s
     end
 
     it "separates the extension from filenames" do


### PR DESCRIPTION
This PR adds a test to illustrate a regression in MIME type detection for `.doc` files, which now return `text/plain` instead of `application/msword` after updating to version 3.7.0.

See related issue: [#224](https://github.com/mime-types/ruby-mime-types/issues/224)
